### PR TITLE
ft: fn to get next available joint id

### DIFF
--- a/fairino_hardware/include/fairino_hardware/command_server.hpp
+++ b/fairino_hardware/include/fairino_hardware/command_server.hpp
@@ -275,6 +275,9 @@ private:
     std::string _def_jnt_position(std::string pos);
     std::string _def_cart_position(std::string pos);
     std::string _get_variable(std::string para_list);
+    // Helpers for point ID management
+    std::string GetNextJNTID(std::string para);
+    std::string GetNextCARTID(std::string para);
     uint16_t _cmd_counter;//指令数据帧计数器
     uint16_t _script_counter;//脚本数据帧计数器
     std::string _cur_func_name;
@@ -303,6 +306,9 @@ private:
     const std::map<std::string,std::string(robot_command_thread::*)(std::string)> _fr_function_list{
     {"JNTPoint",&robot_command_thread::_def_jnt_position},
     {"CARTPoint",&robot_command_thread::_def_cart_position},
+    // Point ID helpers
+    {"NextJNTID",&robot_command_thread::GetNextJNTID},
+    {"NextCARTID",&robot_command_thread::GetNextCARTID},
     {"DragTeachSwitch",&robot_command_thread::DragTeachSwitch},
     {"RobotEnable",&robot_command_thread::RobotEnable},
     {"SetSpeed",&robot_command_thread::SetSpeed},

--- a/fairino_hardware/src/command_server.cpp
+++ b/fairino_hardware/src/command_server.cpp
@@ -672,6 +672,10 @@ std::string robot_command_thread::_def_jnt_position(std::string pos){
         }std::cout<<_recv_data_res<<std::endl;
         iter_data = std::regex_token_iterator<std::string::iterator>(pos.begin(),pos.end(),search_para,-1);
         int idx = atol(iter_data->str().c_str());//指令序号
+        // 支持 id=0 自动追加到末尾
+        if(idx == 0){
+            idx = static_cast<int>(_cmd_jnt_pos_list.size()) + 1;
+        }
         iter_data++;
         if(idx > _cmd_jnt_pos_list.size()+1 || idx <= 0){//如果大于当前容器最大值+1,那么要报错,因为序列容器中间无法留空
             RCLCPP_INFO(rclcpp::get_logger("fairino_hardware"),"Instruction error: Container sequence number is out of limit.");
@@ -718,6 +722,10 @@ std::string robot_command_thread::_def_cart_position(std::string pos){
         }
         iter_data = std::regex_token_iterator<std::string::iterator>(pos.begin(),pos.end(),search_para,-1);
         int idx = atol(iter_data->str().c_str());//指令序号
+        // 支持 id=0 自动追加到末尾
+        if(idx == 0){
+            idx = static_cast<int>(_cmd_cart_pos_list.size()) + 1;
+        }
         iter_data++;
         if(idx > _cmd_cart_pos_list.size()+1 || idx <= 0){//如果大于当前容器最大值+1,那么要报错,因为序列容器中间无法留空
             RCLCPP_INFO(rclcpp::get_logger("fairino_hardware"),"Instruction error: Container sequence number is out of limit.");
@@ -766,6 +774,7 @@ std::string robot_command_thread::_get_variable(std::string para_list){
             }else{
                 RCLCPP_INFO(rclcpp::get_logger("fairino_hardware"),"Instruction error: The sequence number of the input point is out of range.");
                 // std::cout << "指令错误:输入点的序号超出范围" << std::endl;
+                return std::string("0");
             }
         }else if(para_match[1] == "CART"){
                 int idx = atol(para_match[2].str().c_str());
@@ -781,15 +790,30 @@ std::string robot_command_thread::_get_variable(std::string para_list){
                 }else{
                     RCLCPP_INFO(rclcpp::get_logger("fairino_hardware"),"Instruction error: The sequence number of the input point is out of range.");
                     // std::cout << "指令错误:输入点的序号超出范围" << std::endl;
+                    return std::string("0");
                 }
         }else{
             RCLCPP_INFO(rclcpp::get_logger("fairino_hardware"),"Instruction error: Invalid GET instruction parameter.");
             // std::cout << "指令错误: 无效的GET指令参数" << std::endl;
+            return std::string("0");
         }
     }else{
         RCLCPP_INFO(rclcpp::get_logger("fairino_hardware"),"Instruction error: GET instruction parameter is invalid, parameter form is [JNT|CART],[serial number].");
         // std::cout << "指令错误: GET指令参数非法,参数形式为[JNT|CART],[序号]" << std::endl;
+        return std::string("0");
     }
+}
+
+// 获取下一个可用的JNT点ID（当前数量+1）
+std::string robot_command_thread::GetNextJNTID(std::string /*para*/){
+    const auto next_id = static_cast<int>(_cmd_jnt_pos_list.size()) + 1;
+    return std::to_string(next_id);
+}
+
+// 获取下一个可用的CART点ID（当前数量+1）
+std::string robot_command_thread::GetNextCARTID(std::string /*para*/){
+    const auto next_id = static_cast<int>(_cmd_cart_pos_list.size()) + 1;
+    return std::to_string(next_id);
 }
 
 std::string  robot_command_thread::DragTeachSwitch(std::string para){//拖动示教模式切换


### PR DESCRIPTION
This pull request enhances the point management functionality in the `robot_command_thread` class by improving how joint (JNT) and Cartesian (CART) point IDs are handled. It introduces helper methods for retrieving the next available point IDs, updates the command definition logic to support automatic ID assignment, and adds more robust error handling for out-of-range or invalid variable requests.

**Point ID Management Improvements:**

* Added two new helper methods, `GetNextJNTID` and `GetNextCARTID`, to return the next available joint or Cartesian point ID based on the current list size. These methods are now also registered in the `_fr_function_list` for command dispatching. [[1]](diffhunk://#diff-dc901bd61a186a09b05822027ab4dd512003f140c75945cebf709d531f737fc1R278-R280) [[2]](diffhunk://#diff-dc901bd61a186a09b05822027ab4dd512003f140c75945cebf709d531f737fc1R309-R311) [[3]](diffhunk://#diff-7081bc4b2786aed98ed98d187503265d64ff41209f2b5edd3145b984fe21631fR793-R816)

* Updated `_def_jnt_position` and `_def_cart_position` so that specifying `id=0` will automatically append the new point to the end of the respective list, making point addition more user-friendly. [[1]](diffhunk://#diff-7081bc4b2786aed98ed98d187503265d64ff41209f2b5edd3145b984fe21631fR675-R678) [[2]](diffhunk://#diff-7081bc4b2786aed98ed98d187503265d64ff41209f2b5edd3145b984fe21631fR725-R728)

**Error Handling Enhancements:**

* Improved `_get_variable` to return `"0"` when a requested point index is out of range or when invalid parameters are provided, ensuring clearer feedback and preventing potential crashes. [[1]](diffhunk://#diff-7081bc4b2786aed98ed98d187503265d64ff41209f2b5edd3145b984fe21631fR777) [[2]](diffhunk://#diff-7081bc4b2786aed98ed98d187503265d64ff41209f2b5edd3145b984fe21631fR793-R816)