### PR TITLE
Fix broken documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # frcobot_ros2
 This is the ROS2 API project of Fairino robot(sofeware version must greater than V3.7.1), a serial of functions which based on Fair SDK API but were simplified are created, user can call them through service message.
 API_description.md list all API functions.
-Tutorial of installing and uasage of ROS2 API, please refer to the Fair document platform:https://fair-documentation.readthedocs.io/en/latest/ROSGuide/index.html#frcobot-ros2.
+Tutorial of installing and uasage of ROS2 API, please refer to the Fair document platform:[https://fairino-doc-en.readthedocs.io/latest/ROSGuide/index.html#frcobot-ros2](https://fairino-doc-en.readthedocs.io/latest/ROSGuide/index.html#frcobot-ros2).
 
 Version histroy:
 2023.7.18 V1.0


### PR DESCRIPTION
This pull request fixes a broken link in the `README.md`. The previous URL for the Fairino ROS2 API guide was no longer accessible (dead link). I have updated it to point to the correct English documentation.

Fixes #18

### Changes
- **Documentation:**
  * Fixed the broken link for the ROS2 API installation and usage tutorial in `README.md`.