### PR TITLE
feat(hardware): add controller ip as parameters for hardware interface

### DIFF
--- a/fairino_hardware/include/fairino_hardware/fairino_hardware_interface.hpp
+++ b/fairino_hardware/include/fairino_hardware/fairino_hardware_interface.hpp
@@ -12,7 +12,7 @@
 #include "libfairino/include/robot.h"
 
 
-#define CONTROLLER_IP_ADDRESS "192.168.58.2"
+#define DEFAULT_CONTROLLER_IP_ADDRESS "192.168.58.2"
 
 namespace fairino_hardware
 {
@@ -60,7 +60,7 @@ private:
   double _jnt_velocity_state[6];
   double _jnt_torque_state[6];
   int _control_mode;
-  std::string _controller_ip = CONTROLLER_IP_ADDRESS;
+  std::string _controller_ip = DEFAULT_CONTROLLER_IP_ADDRESS;
   std::unique_ptr<FRRobot> _ptr_robot;
 };
 

--- a/fairino_hardware/src/fairino_hardware_interface.cpp
+++ b/fairino_hardware/src/fairino_hardware_interface.cpp
@@ -61,6 +61,12 @@ hardware_interface::CallbackReturn FairinoHardwareInterface::on_init(const hardw
         // }
 
     }
+    if (info_.hardware_parameters.find("controller_ip") == info_.hardware_parameters.end()) {
+        RCLCPP_WARN(rclcpp::get_logger("FairinoHardwareInterface"),
+                    "Hardware parameter 'controller_ip' not found. Using default '%s'", DEFAULT_CONTROLLER_IP_ADDRESS);
+    } else {
+        _controller_ip = info_.hardware_parameters["controller_ip"];
+    }
     return hardware_interface::CallbackReturn::SUCCESS;
 }//end on_init
 


### PR DESCRIPTION
## Purpose
To work with multiple arm system

## How to use
```
<hardware>
    <plugin>fairino_hardware/FairinoHardwareInterface</plugin>
    <param name="controller_ip">192.168.58.3</param>
</hardware>
```

※ Have tested with V3.8.0 