### PR TITLE
Fix: Missing unistd include fails on modern gcc

### DIFF
--- a/fairino_hardware/src/fairino_version.cpp
+++ b/fairino_hardware/src/fairino_version.cpp
@@ -1,12 +1,10 @@
 #include "fairino_version_pkg/fairino_version.hpp"
 #include <sys/types.h>
 #include <sys/socket.h>
-#include "sys/mman.h"
 #include <ament_index_cpp/get_package_share_directory.hpp>  
-#include <regex>                                            
-#include <thread>
 #include <cstdlib>
 #include <ament_index_cpp/get_package_prefix.hpp>
+#include <unistd.h>
 
 
 #define LOGGER_NAME "fairino_ros2_version_thread"


### PR DESCRIPTION
Technically this include should always have been there. But previous gcc versions were more forgiving.
Also removed some unused includes.


If this PR is accepted within a months time, I am happy to also provide jazzy (or newer) support for this repository.